### PR TITLE
fix(agent): resolve tool call error in LangGraph `create_event` tool

### DIFF
--- a/app/agents/scheduler/tool_schema.py
+++ b/app/agents/scheduler/tool_schema.py
@@ -1,6 +1,7 @@
-from typing import List, Optional
+from typing import List, Optional, Annotated
 from datetime import datetime
 from pydantic import BaseModel, Field, EmailStr
+from langchain_core.tools.base import InjectedToolCallId
 
 
 class CreateEventToolArgs(BaseModel):
@@ -19,6 +20,7 @@ class CreateEventToolArgs(BaseModel):
         default=None,
         description="List of attendee email addresses to be invited to the event.",
     )
+    tool_call_id: Annotated[str, InjectedToolCallId]
     # tool_call_id: str = Field(
     #     ...,
     #     description="Unique identifier for the tool call. Used internally to track the assistant's action request.",


### PR DESCRIPTION
* Fixed issue with `create_event` tool call caused by missing parameters in `args_schema` of the `@tool` decorator.
* When a custom `args_schema` (Pydantic model) is defined, LangChain requires all tool arguments to be explicitly included for validation.